### PR TITLE
Calling `#converted_content` before `#convert` produces an error.

### DIFF
--- a/lib/prolog/services/replace_content.rb
+++ b/lib/prolog/services/replace_content.rb
@@ -30,6 +30,7 @@ module Prolog
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def converted_content
+        errors[:conversion] = ['not called'] unless @content_after_conversion
         @content_after_conversion || :oops
       end
 

--- a/test/prolog/services/replace_content_test.rb
+++ b/test/prolog/services/replace_content_test.rb
@@ -192,5 +192,30 @@ describe 'Prolog::Services::ReplaceContent' do
         expect(obj.errors).must_equal expected
       end
     end # describe 'replacing content as specified produces invalid HTML'
+
+    describe 'failing to call #convert prior to calling #converted_content' do
+      let(:endpoints) { (endpoint_begin...endpoint_end) }
+      let(:replacement) { 'replacement content' }
+      let(:content) do
+        '<p>This is <em>source</em> material for the test.</p>'
+      end
+      let(:endpoint_begin) { content.index '<em>source' }
+      let(:endpoint_end) { content.index ' for the test.' }
+
+      before { @content = obj.converted_content }
+
+      it 'is invalid' do
+        expect(obj).wont_be :valid?
+      end
+
+      it 'indicates an error when calling #converted_content' do
+        expect(@content).must_equal :oops
+      end
+
+      it 'returns the correct error data from #errors' do
+        expected = { conversion: ['not called'] }
+        expect(obj.errors).must_equal expected
+      end
+    end # describe 'failing to call #convert prior to ... #converted_content'
   end # describe 'detects errors correctly, including'
 end


### PR DESCRIPTION
Closes #10.

27 tests, 31 assertions, 0 failures, 0 errors, 0 skips
Coverage: 83 / 83 LOC (100.0%) covered
RuboCop: 5 files inspected, no offenses detected
Flay: Total score 0
Flog: Total 69.3; method average 3.5; max 5.5 (Prolog::Services::ReplaceContent#initialize)
Reek: 0 warnings
