### PR TITLE
Beginning endpoint properly validated as within range of content string.

### DIFF
--- a/lib/prolog/services/replace_content.rb
+++ b/lib/prolog/services/replace_content.rb
@@ -78,11 +78,13 @@ module Prolog
       def parse_with_comments
         comment = '<!-- -->'
         twiddled = splitter(comment).source
-        Ox.parse twiddled # raises on most errors
+        ret = Ox.parse twiddled # raises on most errors
+        ret
       end
 
       def splitter(marker = Splitter::Symmetric::DEFAULT_MARKER)
-        Splitter::Factory.call(self, marker)
+        ret = Splitter::Factory.call(self, marker)
+        ret
       end
 
       def validate
@@ -101,12 +103,18 @@ module Prolog
         false
       end
 
+      def _invalidate_endpoints
+        errors[:endpoints] = %w(invalid)
+        false
+      end
+
       def validate_endpoints
         parse_with_comments
         true
       rescue Ox::ParseError
-        errors[:endpoints] = ['invalid']
-        false
+        _invalidate_endpoints
+      rescue RangeError
+        _invalidate_endpoints
       end
     end # class Prolog::Services::ReplaceContent
   end

--- a/lib/prolog/services/replace_content/splitter/symmetric.rb
+++ b/lib/prolog/services/replace_content/splitter/symmetric.rb
@@ -28,7 +28,22 @@ module Prolog
           # content.
           class Parts
             def self.parts(content, endpoints)
-              [content[0...endpoints.begin], content[endpoints.end..-1]]
+              _twiddle(_split(content.dup, endpoints))
+            end
+
+            def self._marker
+              'z|q|x' * 8
+            end
+
+            def self._split(working, endpoints)
+              marker = _marker
+              working[endpoints] = marker
+              working.split marker
+            end
+
+            def self._twiddle(items)
+              return ['', ''] if items.empty?
+              items
             end
           end # class Prolog::Services::ReplaceContent::ContentSplitter::Parts
 

--- a/test/prolog/services/replace_content/splitter/symmetric_test.rb
+++ b/test/prolog/services/replace_content/splitter/symmetric_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'prolog/services/replace_content/splitter/symmetric'
+
+describe 'Prolog::Services::ReplaceContent::Splitter::Symmetric' do
+  let(:described_class) do
+    Prolog::Services::ReplaceContent::Splitter::Symmetric
+  end
+  let(:content) { 'The five boxing wizards jump quickly.' }
+
+  describe 'when initialised using the default (empty) marker' do
+    let(:obj) { described_class.new content: content, endpoints: endpoints }
+
+    describe 'and a non-repeating content string' do
+      describe 'and endpoints are set that' do
+        describe 'include the entire content' do
+          let(:endpoints) { (0..-1) }
+
+          it 'returns the entire original content as the "inner" content' do
+            expect(obj.inner).must_equal content
+          end
+
+          it 'returns the entire original content as the "source" content' do
+            expect(obj.source).must_equal content
+          end
+        end # describe 'include the entire content'
+
+        describe 'include a sub-range of the content' do
+          let(:endpoints) { (4..14) } # "five boxing"
+
+          it 'returns correct original content section as "inner" content' do
+            expect(obj.inner).must_equal content[endpoints]
+          end
+
+          it 'returns the entire original content as the "source" content' do
+            expect(obj.source).must_equal content
+          end
+        end # describe 'include a sub-range of the content'
+      end # describe 'and endpoints are set that'
+    end # describe 'and a non-repeating content string'
+  end # describe 'when initialised using the default (empty) marker'
+
+  describe 'when initialised using an explicit marker' do
+    let(:marker) { '<!-- -->' }
+    let(:obj) do
+      described_class.new content: content, endpoints: endpoints, marker: marker
+    end
+
+    describe 'and endpoints are set that' do
+      describe 'include the entire content' do
+        let(:endpoints) { (0..-1) }
+
+        it 'wraps all original content in a pair of markers as "inner"' do
+          expected = [marker, marker].join content[endpoints]
+          expect(obj.inner).must_equal expected
+        end
+
+        it 'returns the same value for "source" as for "inner"' do
+          expect(obj.source).must_equal obj.inner
+        end
+      end # describe 'include the entire content'
+
+      describe 'include a sub-range of the content' do
+        let(:endpoints) { (4..14) } # "five boxing"
+
+        it 'returns the correct original content section as "inner" content' do
+          expected = [marker, marker].join content[endpoints]
+          expect(obj.inner).must_equal expected
+        end
+
+        it 'returns the entire original content as the "source" content' do
+          parts = content.split content[endpoints]
+          expected = parts.join obj.inner
+          expect(obj.source).must_equal expected
+        end
+      end # describe 'include a sub-range of the content'
+    end # describe 'and endpoints are set that'
+
+    describe 'and a content string with repeating character sequences' do
+      let(:content) do
+        %w(How much wood could a wood chuck chuck if a wood chuck could chuck
+           wood?).join ' '
+      end
+      let(:endpoints) { (44..47) } # third of four 'wood' occurrences
+
+      it 'returns the correct original content section as "inner" content' do
+        expected = [marker, marker].join content[endpoints]
+        expect(obj.inner).must_equal expected
+      end
+
+      it 'returns the entire original content as the "source" content' do
+        expected = content.dup
+        expected[endpoints] = [marker, marker].join content[endpoints]
+        expect(obj.source).must_equal expected
+      end
+    end # describe 'and a content string with repeating character sequences'
+  end # describe 'when initialised using an explicit marker'
+end

--- a/test/prolog/services/replace_content_test.rb
+++ b/test/prolog/services/replace_content_test.rb
@@ -184,27 +184,49 @@ describe 'Prolog::Services::ReplaceContent' do
       end
     end # describe 'invalid enpoints (yielding invalid markup)'
 
-    describe 'invalid endpoints (invalidating content as HTML)' do
-      let(:content) { '<p>This is a <em>simple</em> test.</p>' }
-      let(:endpoints) { (15...23) }
-      let(:replacement) { 'basic' }
+    describe 'endpoints which' do
+      describe 'invalidate the content as HTML' do
+        let(:content) { '<p>This is a <em>simple</em> test.</p>' }
+        let(:endpoints) { (15...23) }
+        let(:replacement) { 'basic' }
 
-      it 'is invalid' do
-        obj.convert
-        expect(obj).wont_be :valid?
-      end
+        it 'is invalid' do
+          obj.convert
+          expect(obj).wont_be :valid?
+        end
 
-      it 'indicates an error when calling #converted_content' do
-        obj.convert
-        expect(obj.converted_content).must_equal :oops
-      end
+        it 'indicates an error when calling #converted_content' do
+          obj.convert
+          expect(obj.converted_content).must_equal :oops
+        end
 
-      it 'returns the correct error data from #errors' do
-        obj.convert
-        expected = { endpoints: ['invalid'] }
-        expect(obj.errors).must_equal expected
-      end
-    end # describe 'invalid endpoints (invalidating content as HTML)'
+        it 'returns the correct error data from #errors' do
+          obj.convert
+          expected = { endpoints: ['invalid'] }
+          expect(obj.errors).must_equal expected
+        end
+      end # describe 'invalidate the content as HTML'
+
+      describe 'are out of valid range with respect to the content' do
+        let(:content) { '<p>Testing.</p>' }
+        let(:endpoints) { (0..-1) }
+        let(:replacement) { 'anything' }
+
+        after do
+          obj.convert
+          expected = { endpoints: ['invalid'] }
+          expect(obj.errors).must_equal expected
+        end
+
+        it 'begin index' do
+          params[:endpoints] = (800..-1)
+        end
+
+        # it 'end index' do
+        #   params[:endpoints] = (0..800)
+        # end
+      end # describe 'are out of valid range with respect to the content'
+    end # describe 'endpoints which'
 
     describe 'replacing content as specified produces invalid HTML' do
       let(:content) { '<ul><li>First item</li><li>Second item</li></ul>' }


### PR DESCRIPTION
Closes #13 with Commit b195702.

Leaves as documented but undesirable behaviour the fact that specifying an out-of-range ending endpoint for replacing content will be treated as functionally identical to an ending endpoint value of -1 or of the actual end of the string; after some deliberation, this seems more reasonable and more consistent with "how Ruby strings work" than adding yet more code that introduces behaviour that a Ruby-comfortable user (developer) may find surprising.

Disagree? Open a PR!

Merging this PR will complete known work for Gem Release 0.1.1.
